### PR TITLE
Adding storage_table_host url to prevent variable leak

### DIFF
--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -72,6 +72,7 @@ class LogStash::Inputs::Azureblob < LogStash::Inputs::Base
     Azure.configure do |config|
       config.storage_account_name = @storage_account_name
       config.storage_access_key = @storage_access_key
+      config.storage_table_host = "https://#{@storage_account_name}.table.core.windows.net"
     end
     @azure_blob = Azure::Blob::BlobService.new
     


### PR DESCRIPTION
If you use this plugin with the azurewadtable one on the same logstash instance you'll get the table url for sincedb set to the storageaccountname of the latest azurewadtable input you have used. I don't explain it, but this commit fixes that.
