### PR TITLE
Typo in ByteOffset name

### DIFF
--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -206,7 +206,7 @@ class LogStash::Inputs::Azureblob < LogStash::Inputs::Base
           entity["ETag"] = foundEntity.properties["ETag"] 
         elsif (@start_position === "end")
           # first contact
-          entity["byteOffset"] = blob_info.properties[:content_length]
+          entity["ByteOffset"] = blob_info.properties[:content_length]
         end
 
         if (entity["ETag"] === blob_info.properties[:etag])


### PR DESCRIPTION
having other issues I stumbled upon this, I think it's a mistake right ? Even though I do have my ByteOffset field filled up in my table but I think that the first pass might read the whole blob instead of just setting the pointer to the end of it.