### PR TITLE
Fix for continuation_token reset in loop

### DIFF
--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -104,8 +104,8 @@ class LogStash::Inputs::Azureblob < LogStash::Inputs::Base
     @logger.info("#{DateTime.now} Looking for blobs in #{path_prefix.length} paths (#{path_prefix.to_s})...")
 
     path_prefix.each do |prefix|
+      continuation_token = NIL
       loop do
-        continuation_token = NIL
         entries = @azure_blob.list_blobs(@container, { :timeout => 10, :marker => continuation_token, :prefix => prefix})
         entries.each do |entry|
           entry_last_modified = DateTime.parse(entry.properties[:last_modified]) # Normally in GMT 0
@@ -114,7 +114,6 @@ class LogStash::Inputs::Azureblob < LogStash::Inputs::Base
             blobs[entry.name] = entry
           end
         end
-
         continuation_token = entries.continuation_token
         break if continuation_token.empty?
       end


### PR DESCRIPTION
The continuation token was reset in the loop so the query was looping indefinitely if azure returns a continuation token. Moving it out of the loop fixes the issue.